### PR TITLE
Update the scripts to use `xtrabackup` instead of `innobackupex`

### DIFF
--- a/extract-mysql.sh
+++ b/extract-mysql.sh
@@ -49,14 +49,14 @@ do_extraction () {
         mkdir --verbose -p "${restore_dir}"
         xbstream -x -C "${restore_dir}" < "${file}"
 
-        innobackupex_args=(
+        xtrabackup_args=(
             "--parallel=${processors}"
             "--decrypt=AES256"
             "--encrypt-key-file=${encryption_key_file}"
             "--decompress"
         )
 
-        innobackupex "${innobackupex_args[@]}" "${restore_dir}"
+        xtrabackup "${xtrabackup_args[@]}" --target-dir="${restore_dir}"
         find "${restore_dir}" -name "*.xbcrypt" -exec rm {} \;
         find "${restore_dir}" -name "*.qp" -exec rm {} \;
     
@@ -73,7 +73,7 @@ ok_count="$(grep -c 'completed OK' "${log_file}")"
 # informational "completed OK".  If the processing was successful, an
 # additional "completed OK" is printed. Together, this means there should be 2
 # notices per backup file if the process was successful.
-if (( $ok_count !=  2 * $# )); then
+if (( $ok_count !=  $# )); then
     error "It looks like something went wrong. Please check the \"${log_file}\" file for additional information"
 else
     printf "Extraction complete! Backup directories have been extracted to the \"restore\" directory.\n"

--- a/prepare-mysql.sh
+++ b/prepare-mysql.sh
@@ -34,15 +34,15 @@ sanity_check () {
 do_backup () {
     # Apply the logs to each of the backups
     printf "Initial prep of full backup %s\n" "${full_backup_dir}"
-    innobackupex --redo-only --apply-log "${full_backup_dir}"
+    xtrabackup --prepare --apply-log-only --target-dir="${full_backup_dir}"
     
     for increment in "${incremental_dirs[@]}"; do
         printf "Applying incremental backup %s to %s\n" "${increment}" "${full_backup_dir}"
-        innobackupex --redo-only --apply-log --incremental-dir="${increment}" "${full_backup_dir}"
+        xtrabackup --prepare --apply-log-only --incremental-dir="${increment}" --target-dir="${full_backup_dir}"
     done
     
     printf "Applying final logs to full backup %s\n" "${full_backup_dir}"
-    innobackupex --apply-log "${full_backup_dir}"
+    xtrabackup --prepare --target-dir="${full_backup_dir}"
 }
 
 sanity_check && do_backup > "${log_file}" 2>&1
@@ -52,7 +52,7 @@ sanity_check && do_backup > "${log_file}" 2>&1
 # the process, a final full apply is performed, generating another 2 messages.
 ok_count="$(grep -c 'completed OK' "${log_file}")"
 
-if (( ${ok_count} == 2 * (${#full_dirs[@]} + ${#incremental_dirs[@]} + 1) )); then
+if (( ${ok_count} == ${#full_dirs[@]} + ${#incremental_dirs[@]} + 1 )); then
     cat << EOF
 Backup looks to be fully prepared.  Please check the "prepare-progress.log" file
 to verify before continuing.
@@ -67,7 +67,7 @@ First, stop MySQL and move or remove the contents of the MySQL data directory:
 Then, recreate the data directory and  copy the backup files:
     
         sudo mkdir /var/lib/mysql
-        sudo innobackupex --copy-back ${PWD}/$(basename "${full_backup_dir}")
+        sudo xtrabackup --copy-back --target-dir=${PWD}/$(basename "${full_backup_dir}")
     
 Afterward the files are copied, adjust the permissions and restart the service:
     


### PR DESCRIPTION
When these scripts were first written, `xtrabackup` was not able to
fully replicate the functionality of `innobackupex`.  If I remember
correctly, some of the incremental backup options were not available
previously.  However, with further development, these two tools now
have feature parity (at least as far as these scripts require) and
the `innobackupex` tool has been deprecated.  This moves the scripts to
use `xtrabackup` since `innobackupex` will be removed in future
releases.