### PR TITLE
use $(id -un) instead of $USER for sanity check with cron

### DIFF
--- a/backup-mysql.sh
+++ b/backup-mysql.sh
@@ -22,7 +22,7 @@ trap 'error "An unexpected error occurred."' ERR
 
 sanity_check () {
     # Check user running the script
-    if [ "$USER" != "$backup_owner" ]; then
+    if [ "$(id -un)" != "$backup_owner" ]; then
         error "Script can only be run as the \"$backup_owner\" user"
     fi
     

--- a/download-day.sh
+++ b/download-day.sh
@@ -16,7 +16,7 @@ trap 'error "An unexpected error occurred."' ERR
 
 sanity_check () {
     # Check user running the script
-    if [ "$USER" != "$backup_owner" ]; then
+    if [ "$(id -un)" != "$backup_owner" ]; then
         error "Script can only be run as the \"$backup_owner\" user"
     fi
 

--- a/remote-backup-mysql.sh
+++ b/remote-backup-mysql.sh
@@ -24,7 +24,7 @@ trap 'error "An unexpected error occurred."' ERR
 
 sanity_check () {
     # Check user running the script
-    if [ "$USER" != "$backup_owner" ]; then
+    if [ "$(id -un)" != "$backup_owner" ]; then
         error "Script can only be run as the \"$backup_owner\" user"
     fi
 


### PR DESCRIPTION
$USER is not set in cron. This patch allows backup-mysql to run under cron without extra configuration. It also provides some protection against contexts in which the $USER environment variable may be incorrectly set by other programs or actions.