### PR TITLE
Fix date parsing to get date string more accurately.

### DIFF
--- a/remote-backup-mysql.sh
+++ b/remote-backup-mysql.sh
@@ -57,7 +57,7 @@ set_backup_type () {
     fi
 
     # Grab today's date, in the same format
-    todays_date="$(date -d"$(echo "${now}" | cut -d' ' -f 1-3)" +%s)"
+    todays_date="$(date -d "$(date -d "${now}" "+%D")" +%s)"
 
     # Compare the two dates
     (( $last_backup_date == $todays_date ))


### PR DESCRIPTION
Previously, `todays_date` in the `remote-backup-mysql.sh` script tried
to cut out the date from a date and time string using the `cut` utility.
This lead to errors when the format was not exactly as expected. To fix
this, we can just let `date` display the fields we need and then output
in the required format.